### PR TITLE
remove ffmpeg absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ If the configuration and steps above is complete, you can heads up to http://[yo
 - `-path` The full path of the video directory
 - `-tmdb-key` API key of TMDB, you can grab one at [Official TMDB API](https://www.themoviedb.org/documentation/api)
 - `-port` (optional) The port number for the server to run, default to 1818
-- `-ffmpeg-bin` (optional) The path of FFmpeg binary, if you have a different path of FFmpeg
 - `-resolution` (optional) By default the program will produce 4 resolution (360p, 480p, 720p and 1080p), this option can be supplied multiple times
 
 ### Some Screenshots

--- a/collections/extract_hls.go
+++ b/collections/extract_hls.go
@@ -171,7 +171,7 @@ func createm3u8Playlist(path string, res []string) {
 }
 
 // ExtractMovHLS will generate HLS files
-func ExtractMovHLS(movieFilePath, destDir, ffmpegPathBin string, reso []string) (bool, []TranscodingError) {
+func ExtractMovHLS(movieFilePath, destDir string, reso []string) (bool, []TranscodingError) {
 	availableResolutions := map[string]func(string, string) []string{
 		"360p":  cmdHLS360p,
 		"480p":  cmdHLS480p,
@@ -195,7 +195,7 @@ func ExtractMovHLS(movieFilePath, destDir, ffmpegPathBin string, reso []string) 
 	output := make(chan TranscodingError, len(resolutions))
 	for reso, cmdStrings := range resolutions {
 		go func(out chan<- TranscodingError, commandProducer func(string, string) []string, resolution string) {
-			cmd := exec.Command(ffmpegPathBin, commandProducer(movieFilePath, destDir)...)
+			cmd := exec.Command("ffmpeg", commandProducer(movieFilePath, destDir)...)
 			cmd.Stdout = logrus.New().Out
 			cmd.Stderr = logrus.New().Out
 
@@ -257,7 +257,6 @@ func DoExtraction(movie *models.Movie, cfg *config.ServerConfig) (bool, []Transc
 	return ExtractMovHLS(
 		filepath.Join(movie.DirPath, movie.BaseName),
 		extractionDirName,
-		cfg.FFmpegBin,
 		cfg.ScreenResolutions,
 	)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,7 +13,6 @@ func Setup() {
 		TimestampFormat: "02-Jan-2006 15:04:05", // https://golang.org/src/time/format.go
 		FullTimestamp:   true,
 	})
-
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logger.DebugLevel)
 }


### PR DESCRIPTION
Hi slaveofcode:

when we use `exec.Command("ffmpeg", "-i", "inputfile", "-vcodec", "copy", "-acodec", "copy", "outputfile")`, we don't need to specified the absolute path of ffmpeg, just use "ffmpeg", is works fine, in most OS, when we install ffmpeg, it's executable path will be added to PATH vaeiable automaticlly. so I remove ffmpegPathBin config.  and recompile the code with `go build .`, run it, it works fine.
```sh
./voodio.exe  -tmdb-key mytmdbkey --port 8080    -path   D:\\videos
INFO[22-Dec-2020 18:42:27] Obsolete DB detected, removing...
INFO[22-Dec-2020 18:42:27] DB initialized at C:\Users\myname\AppData\Local\voodioapp\voodio.db
INFO[22-Dec-2020 18:42:27] Preparing database...
INFO[22-Dec-2020 18:42:27] Database prepared
INFO[22-Dec-2020 18:42:27] Scanning movies...
INFO[22-Dec-2020 18:42:27] Scanning movies finished
INFO[22-Dec-2020 18:42:27] Activate API Server
INFO[22-Dec-2020 18:42:27] Server is alive
INFO[22-Dec-2020 18:42:27] http://mybublicip:8080
INFO[22-Dec-2020 18:42:27] http://myinternalip:8080
INFO[22-Dec-2020 18:42:27] http://myinternalip:8080
INFO[22-Dec-2020 18:42:27] http://127.0.0.1:8080
DEBU[22-Dec-2020 18:42:45] reso [360p 480p 720p 1080p]
DEBU[22-Dec-2020 18:42:45] generated reso map[1080p:0x1134f60 360p:0x11348a0 480p:0x1134ae0 720p:0x1134d20]
DEBU[22-Dec-2020 18:42:45] #EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:BANDWIDTH=800000,RESOLUTION=640x360
360p.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1400000,RESOLUTION=842x480
480p.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=2800000,RESOLUTION=1280x720
720p.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
1080p.m3u8
INFO[22-Dec-2020 18:42:45] Exec: ffmpeg -hide_banner -y -i D:\videos\x.mp4 -vf scale=trunc(oh*a/2)*2:1080 -c:a aac -ar 48000 -c:v h264 -profile:v main -crf 20 -sc_threshold 0 -g 48 -keyint_min 48 -hls_time 10 -hls_playlist_type vod -b:v 5000k -maxrate 5350k -bufsize 7500k -b:a 192k -preset ultrafast -hls_segment_filename C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\1080p_%03d.ts C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\1080p.m3u8
INFO[22-Dec-2020 18:42:45] Exec: ffmpeg -hide_banner -y -i D:\videos\x.mp4 -vf scale=trunc(oh*a/2)*2:480 -c:a aac -ar 48000 -c:v h264 -profile:v main -crf 20 -sc_threshold 0 -g 48 -keyint_min 48 -hls_time 10 -hls_playlist_type vod -b:v 1400k -maxrate 1498k -bufsize 2100k -b:a 128k -preset ultrafast -hls_segment_filename C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\480p_%03d.ts C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\480p.m3u8
INFO[22-Dec-2020 18:42:45] Exec: ffmpeg -hide_banner -y -i D:\videos\x.mp4 -vf scale=trunc(oh*a/2)*2:360 -c:a aac -ar 48000 -c:v h264 -profile:v main -crf 20 -sc_threshold 0 -g 48 -keyint_min 48 -hls_time 10 -hls_playlist_type vod -b:v 800k -maxrate 856k -bufsize 1200k -b:a 96k -hls_segment_filename C:\Users\g00455772\AppData\Local\voodioapp\generated_hls\2\360p_%03d.ts C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\360p.m3u8
INFO[22-Dec-2020 18:42:45] Exec: ffmpeg -hide_banner -y -i D:\videos\x.mp4 -vf scale=trunc(oh*a/2)*2:720 -c:a aac -ar 48000 -c:v h264 -profile:v main -crf 20 -sc_threshold 0 -g 48 -keyint_min 48 -hls_time 10 -hls_playlist_type vod -b:v 2800k -maxrate 2996k -bufsize 4200k -b:a 128k -preset ultrafast -hls_segment_filename C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\720p_%03d.ts C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\720p.m3u8
INFO[22-Dec-2020 18:42:45] Extracting HLS finished: x
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'D:\videos\x.mp4':
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'D:\videos\x.mp4':Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'D:\videos\x.mp4':
....................
[hls @ 00000151edef1700] Opening 'C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\360p_001.ts' for writing
[hls @ 000001cda0971740] Opening 'C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\720p_001.ts' for writing
[hls @ 000002742f211740] Opening 'C:\Users\myname\AppData\Local\voodioapp\generated_hls\2\480p_001.ts' for writing
...........
```
if you want to check if ffmpeg was installed on the host OS, I write a snippet code, if you don't like it, just ignore









